### PR TITLE
fix/refacto: allow memoization of files in validateModel with upgrade of ramda

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kilix/functional-validation",
-    "version": "2.3.5",
+    "version": "2.4.0",
     "description": "Lightweight and customisable validation, built through composition",
     "main": "lib/index.js",
     "scripts": {
@@ -59,7 +59,7 @@
         "webpack-cli": "^3.3.6"
     },
     "dependencies": {
-        "ramda": "^0.23.0"
+        "ramda": "^0.27.0"
     },
     "peerDependencies": {},
     "lint-staged": {

--- a/src/validateModel.js
+++ b/src/validateModel.js
@@ -1,6 +1,6 @@
 // @flow
 import pipe from 'ramda/src/pipe';
-import memoize from 'ramda/src/memoize';
+import memoizeWith from 'ramda/src/memoizeWith';
 import flattenR from 'ramda/src/flatten';
 import mapR from 'ramda/src/map';
 import filterR from 'ramda/src/filter';
@@ -25,13 +25,24 @@ export type ModelValidatorT<T, P: $ReadOnlyArray<any> = []> = (
 ) => $ReadOnlyArray<ErrorT>;
 export type ValidationsT<T, P: $ReadOnlyArray<any>> = $ReadOnlyArray<ValidationT<T, P>>;
 
+function isEqual(elem: Object) {
+    const newElem = {
+        ...elem,
+        ...(elem.files ? { files: elem.files.map(({ name, size }) => ({ name, size })) } : {}),
+        ...(elem.file ? { file: { name: elem.file.name, size: elem.file.size } } : {}),
+    };
+
+    return JSON.stringify(newElem);
+}
 function validateModel<T, P: $ReadOnlyArray<any>>(
     validations: ValidationsT<T, P>,
 ): ModelValidatorT<T, P> {
-    return memoize((model: T, ...params: P): $ReadOnlyArray<ErrorT> =>
-        pipe(map(validation => validation(model, ...params)), flatten, filter(Boolean))(
-            validations,
-        ),
+    return memoizeWith(isEqual, (model: T, ...params: P): $ReadOnlyArray<ErrorT> =>
+        pipe(
+            map(validation => validation(model, ...params)),
+            flatten,
+            filter(Boolean),
+        )(validations),
     );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5758,10 +5758,10 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
-ramda@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.23.0.tgz#ccd13fff73497a93974e3e86327bfd87bd6e8e2b"
-  integrity sha1-zNE//3NJepOXTj6GMnv9h71ujis=
+ramda@^0.27.0:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randombytes@^2.0.0, randombytes@^2.0.1:
   version "2.0.5"


### PR DESCRIPTION
Upgrade ramda to use MemoizeWith and custom memoisation for validateModel